### PR TITLE
scripts: remove docker clean from multi_build.bash

### DIFF
--- a/scripts/clean_dirs.bash
+++ b/scripts/clean_dirs.bash
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# NB: the values of $BUILD_DIR $DIR $parent_dir $gparent_dir should
+# be set in the callee.
+
+for dir in "$BUILD_DIR" "$DIR" "$parent_dir" "$gparent_dir"; do
+  rm -rf "$dir"/{nodes,peers.json,lachesis_d*}
+done

--- a/scripts/docker/clean.bash
+++ b/scripts/docker/clean.bash
@@ -2,17 +2,13 @@
 
 set -euo pipefail
 
-declare -r DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-declare -r parent_dir="${DIR%/*}"
-declare -r gparent_dir="${parent_dir%/*}"
+declare -xr DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+declare -xr parent_dir="${DIR%/*}"
+declare -xr gparent_dir="${parent_dir%/*}"
 declare -r DOCKER_PID=/var/run/docker.pid
 
 . "${DIR%/*}/set_globals.bash"
-
-
-for dir in "$BUILD_DIR" "$DIR" "$parent_dir" "$gparent_dir"; do
-  rm -rf "$dir"/{nodes,peers.json,lachesis_d*}
-done
+. "${DIR%/*}/clean_dirs.bash"
 
 if [ ! -f "$DOCKER_PID" ] || [ ! $(pgrep --pidfile "$DOCKER_PID") ]; then
   exit 0

--- a/scripts/multi_build.bash
+++ b/scripts/multi_build.bash
@@ -3,14 +3,12 @@
 set -euo pipefail
 OPTIND=1         # Reset in case getopts has been used previously in the shell.
 
-declare -r DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-declare -r parent_dir="${DIR%/*}"
-declare -r gparent_dir="${parent_dir%/*}"
+declare -xr DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+declare -xr parent_dir="${DIR%/*}"
+declare -xr gparent_dir="${parent_dir%/*}"
 
 . "$DIR/set_globals.bash"
-for dir in "$BUILD_DIR" "$DIR" "$parent_dir" "$gparent_dir"; do
-  rm -rf "$dir"/{nodes,peers.json,lachesis_d*}
-done
+. "$DIR/clean_dirs.bash"
 . "$DIR/ncpus.bash"
 
 # Config

--- a/scripts/multi_build.bash
+++ b/scripts/multi_build.bash
@@ -8,7 +8,9 @@ declare -r parent_dir="${DIR%/*}"
 declare -r gparent_dir="${parent_dir%/*}"
 
 . "$DIR/set_globals.bash"
-"$DIR/docker/clean.bash"
+for dir in "$BUILD_DIR" "$DIR" "$parent_dir" "$gparent_dir"; do
+  rm -rf "$dir"/{nodes,peers.json,lachesis_d*}
+done
 . "$DIR/ncpus.bash"
 
 # Config


### PR DESCRIPTION
Docker is not used in multi_* so is no need to check if it is running.