### PR TITLE
src/{poset,node}: remove redundant maps

### DIFF
--- a/src/node/graph.go
+++ b/src/node/graph.go
@@ -42,7 +42,7 @@ func (g *Graph) GetParticipantEvents() map[string]map[poset.EventHash]poset.Even
 	res := make(map[string]map[poset.EventHash]poset.Event)
 
 	store := g.Node.core.poset.Store
-	repertoire := g.Node.core.poset.Store.RepertoireByPubKey()
+	repertoire := g.Node.core.poset.Participants.ToPeerSlice()
 	known := store.KnownEvents()
 	for _, p := range repertoire {
 		root, err := store.GetRoot(p.PubKeyHex)

--- a/src/poset/badger_store.go
+++ b/src/poset/badger_store.go
@@ -245,16 +245,6 @@ func (s *BadgerStore) Participants() (*peers.Peers, error) {
 	return s.participants, nil
 }
 
-// RepertoireByPubKey gets PubKey map of peers
-func (s *BadgerStore) RepertoireByPubKey() map[string]*peers.Peer {
-	return s.inmemStore.RepertoireByPubKey()
-}
-
-// RepertoireByID gets ID map of peers
-func (s *BadgerStore) RepertoireByID() map[uint64]*peers.Peer {
-	return s.inmemStore.RepertoireByID()
-}
-
 // RootsBySelfParent returns the roots for the self parent
 func (s *BadgerStore) RootsBySelfParent() (map[EventHash]Root, error) {
 	return s.inmemStore.RootsBySelfParent()

--- a/src/poset/inmem_store.go
+++ b/src/poset/inmem_store.go
@@ -26,8 +26,6 @@ type InmemStore struct {
 	frameCache             *lru.Cache           // round received => Frame
 	consensusCache         *common.RollingIndex // consensus index => hash
 	totConsensusEvents     int64
-	repertoireByPubKey     map[string]*peers.Peer
-	repertoireByID         map[uint64]*peers.Peer
 	participantEventsCache *ParticipantEventsCache // pubkey => Events
 	rootsByParticipant     map[string]Root         // [participant] => Root
 	rootsBySelfParent      map[EventHash]Root      // [Root.SelfParent.Hash] => Root
@@ -89,8 +87,6 @@ func NewInmemStore(participants *peers.Peers, cacheSize int, posConf *pos.Config
 		blockCache:             blockCache,
 		frameCache:             frameCache,
 		consensusCache:         common.NewRollingIndex("ConsensusCache", cacheSize),
-		repertoireByPubKey:     make(map[string]*peers.Peer),
-		repertoireByID:         make(map[uint64]*peers.Peer),
 		participantEventsCache: NewParticipantEventsCache(cacheSize, participants),
 		rootsByParticipant:     rootsByParticipant,
 		lastRound:              -1,
@@ -104,8 +100,6 @@ func NewInmemStore(participants *peers.Peers, cacheSize int, posConf *pos.Config
 	participants.OnNewPeer(func(peer *peers.Peer) {
 		root := NewBaseRoot(peer.ID)
 		store.rootsByParticipant[peer.PubKeyHex] = root
-		store.repertoireByPubKey[peer.PubKeyHex] = peer
-		store.repertoireByID[peer.ID] = peer
 		store.rootsBySelfParent = nil
 		if _, err := store.RootsBySelfParent(); err != nil {
 			panic(err)
@@ -115,7 +109,6 @@ func NewInmemStore(participants *peers.Peers, cacheSize int, posConf *pos.Config
 		store.participantEventsCache.Import(old)
 	})
 
-	store.setPeers(0, participants)
 	if err = store.setLeafEvents(store.rootsByParticipant); err != nil {
 		panic(err)
 	}
@@ -148,26 +141,6 @@ func (s *InmemStore) CacheSize() int {
 // Participants returns participants
 func (s *InmemStore) Participants() (*peers.Peers, error) {
 	return s.participants, nil
-}
-
-func (s *InmemStore) setPeers(round int64, participants *peers.Peers) {
-	// Extend ParticipantEventsCache and Roots with new peers
-	participants.RLock()
-	defer participants.RUnlock()
-	for _, peer := range participants.ByID {
-		s.repertoireByPubKey[peer.PubKeyHex] = peer
-		s.repertoireByID[peer.ID] = peer
-	}
-}
-
-// RepertoireByPubKey retrieves cached PubKey map of peers
-func (s *InmemStore) RepertoireByPubKey() map[string]*peers.Peer {
-	return s.repertoireByPubKey
-}
-
-// RepertoireByID retrieve cached ID map of peers
-func (s *InmemStore) RepertoireByID() map[uint64]*peers.Peer {
-	return s.repertoireByID
 }
 
 // RootsBySelfParent TODO

--- a/src/poset/store.go
+++ b/src/poset/store.go
@@ -14,8 +14,6 @@ type Store interface {
 	TopologicalEvents() ([]Event, error) // returns event in topological order
 	CacheSize() int
 	Participants() (*peers.Peers, error)
-	RepertoireByPubKey() map[string]*peers.Peer
-	RepertoireByID() map[uint64]*peers.Peer
 	RootsBySelfParent() (map[EventHash]Root, error)
 	GetEventBlock(EventHash) (Event, error)
 	SetEvent(Event) error


### PR DESCRIPTION
Store.RepertoireByPubKey and Store.RepertoireByID duplicate data and functionality in Peers, so we just remove this duplication.