### PR TITLE
Makefile: fix go flags used for tests for Go 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.11.x
+- 1.12.x
 go_import_path: github.com/Fantom-foundation/go-lachesis
 cache:
   directories:

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ dist:
 	@BUILD_TAGS='$(BUILD_TAGS)' $(SH) -c "'$(CURDIR)/scripts/dist.sh'"
 
 test:
-	$(GLIDE) novendor | $(GREP) -v -e "^\.$$" | GOCACHE=off $(XARGS) $(GO) test -tags test -race -timeout 180s
+	$(GLIDE) novendor | $(GREP) -v -e "^\.$$" | $(XARGS) $(GO) test -count=1 -tags test -race -timeout 180s
 
 # clean up and generate protobuf files
 proto: clean


### PR DESCRIPTION
Change required to run tests without caching under Go 1.2, see https://github.com/golang/go/issues/29378